### PR TITLE
Change `epoch` to use UTC instead of local timezone

### DIFF
--- a/eha_jsonpath/ext_functions.py
+++ b/eha_jsonpath/ext_functions.py
@@ -221,7 +221,7 @@ class ParseEpochDatetime(BaseFn):
             raise DefintionInvalid(
                 f'{self.time_format} is invalid: excepted {self.VALID_FORMATS.keys()}')
         deno = self.VALID_FORMATS[self.time_format]
-        value = datetime.fromtimestamp(float(obj) / deno)
+        value = datetime.utcfromtimestamp(float(obj) / deno)
         return ParseDatetime.args_to_slice(
             self.slice_arg, value.isoformat())
 


### PR DESCRIPTION
I noticed that tests fail if running in a timezone west of UTC.

There are two ways to fix that... ;) but since the `epoch` functionality is
quite new, I hope that changing its functionality is a good choice, rather
than just fixing the tests to match the behavior.

This change makes a functional difference to the `epoch` extension:
it now interprets epoch values as being UTC, where previously they were
interpreted in the local timezone.

Tests are unchanged but now pass regardless of the timezone they run in.